### PR TITLE
attempt to fix travis build

### DIFF
--- a/libgraphdb/BUILD
+++ b/libgraphdb/BUILD
@@ -47,6 +47,7 @@ cc_library(
     ],
     hdrs = [
         "graphdb.h",
+        "graphdb-args.h",
         "graphdbp.h",
     ],
     copts = ["-g"],
@@ -58,14 +59,14 @@ cc_library(
 )
 
 cc_binary(
-  name = "graphdb-to-dot",
-  srcs = [
-      "graphdb-to-dot.c",
-  ],
-  deps = [
-    "//libcl",
-    "//libcm",
-    "//libgraph",
-    "//libgraphdb",
-  ],
+    name = "graphdb-to-dot",
+    srcs = [
+        "graphdb-to-dot.c",
+    ],
+    deps = [
+        "//libcl",
+        "//libcm",
+        "//libgraph",
+        "//libgraphdb",
+    ],
 )


### PR DESCRIPTION
From https://travis-ci.org/google/graphd/builds/427500063
```
[244 / 246] 2 actions running
    Compiling libgraphdb/graphdb-request-free.c; 0s linux-sandbox
    Compiling libgraphdb/graphdb-buffer-free.c; 0s linux-sandbox
 ./libgraphdb/graphdbp.h:32:0
                 from libgraphdb/graphdb-request-free.c:13:
./libgraphdb/graphdb.h:304:37: fatal error: libgraphdb/graphdb-args.h: No such file or directory
 #include "libgraphdb/graphdb-args.h"
```