### PR TITLE
remove user/group 'nobody' settings from bigconf, they dont exist in

### DIFF
--- a/test/unit/bigconf.conf
+++ b/test/unit/bigconf.conf
@@ -1,7 +1,5 @@
 log-level fatal
 pid-file bigconf.conf
-user nobody
-group nobody
 log-facility local3
 log-file blah
 pool-min 12


### PR DESCRIPTION
travis builds..at least not without more configuration that i dont think we need.