### PR TITLE
graphd,libpdb,libsrv: build graphd for freebsd

### DIFF
--- a/graphd/graphd-database.c
+++ b/graphd/graphd-database.c
@@ -199,7 +199,11 @@ again:
              "%s: no database at \"%s\": "
              "create/extract a database dir. ",
              srv_program_name(srv), dcf->dcf_path);
+#if __FreeBSD__
+    } else if (err == EIO && try_snapshot) {
+#else
     } else if (err == ENODATA && try_snapshot) {
+#endif
       /* A stale lock file was found in the database
        * directory. The database is probably unsafe to use,
        * so let's try to boot from a snapshot.
@@ -281,7 +285,11 @@ again:
              "%s: shut down that "
              "process before starting a new one.",
              srv_program_name(srv));
+#if __FreeBSD__
+    } else if (err == EIO && try_snapshot) {
+#else
     } else if (err == ENODATA && try_snapshot) {
+#endif
       /* A stale lock file was found in the database
        * directory. The database is probably unsafe to use,
        * so let's try to boot from a snapshot.

--- a/graphd/graphd-snapshot.c
+++ b/graphd/graphd-snapshot.c
@@ -23,7 +23,7 @@ limitations under the License.
  * Load the most recent snapshot of the database.
  *
  * Returns zero on success, otherwise a positive error code, in particular
- * ENODATA if a snapshot is not available.
+ * ENODATA if a snapshot is not available (EIO on FreeBSD).
  */
 int graphd_snapshot_restore(graphd_handle* g, srv_handle* srv,
                             graphd_database_config const* dcf) {
@@ -44,7 +44,11 @@ int graphd_snapshot_restore(graphd_handle* g, srv_handle* srv,
 
   if (dcf->dcf_snap == NULL) {
     cl_log(cl, CL_LEVEL_ERROR, "%s(): no snapshot directory specified", fn);
+#if __FreeBSD__
+    return EIO;
+#else
     return ENODATA;
+#endif
   }
 
   /*
@@ -77,7 +81,11 @@ int graphd_snapshot_restore(graphd_handle* g, srv_handle* srv,
 retry:
   if (attempts >= attempts_max) {
     cl_log(cl, CL_LEVEL_ERROR, "%s(): giving up", fn);
+#if __FreeBSD__
+    return EIO;
+#else
     return ENODATA;
+#endif
   } else if (attempts > 0) {
     sleep(1);
     cl_log(cl, CL_LEVEL_ERROR, "%s(): retrying...", fn);
@@ -108,7 +116,11 @@ retry:
   if (strncmp(name, "graph.", 6))  // just in case..
   {
     cl_log(cl, CL_LEVEL_ERROR, "%s(): unexpected snapshot name: %s", fn, name);
+#if __FreeBSD__
+    return EIO;
+#else
     return ENODATA;
+#endif
   }
 
   cl_log(cl, CL_LEVEL_INFO, "%s(): most recent snapshot: %s", fn, name);

--- a/libpdb/pdb-configure.c
+++ b/libpdb/pdb-configure.c
@@ -28,7 +28,7 @@ limitations under the License.
 #define PDB_MEMORY_MAP_SLOTS (64 * 1024ull)
 #endif
 
-#if __APPLE__
+#if __APPLE__ || __FreeBSD__
 
 #ifndef USE_SYSCTL
 #define USE_SYSCTL 1

--- a/libpdb/pdb-lockfile.c
+++ b/libpdb/pdb-lockfile.c
@@ -554,7 +554,11 @@ int pdb_lockfile_create(pdb_handle *pdb, char const *lockfile_path) {
       cl_log(pdb->pdb_cl, CL_LEVEL_ERROR,
              "pdb_lockfile_create: stale lock-file detected, "
              "database is probably corrupted");
+#if __FreeBSD__
+      err = EIO;
+#else
       err = ENODATA;
+#endif
       break;
     } else if (rename(replacement_path, lockfile_path) != 0) {
       cl_log(pdb->pdb_cl, CL_LEVEL_SPEW,

--- a/libsrv/BUILD
+++ b/libsrv/BUILD
@@ -40,6 +40,7 @@ cc_library(
         "srv.h",
         "srv-interface.h",
         "srv-interface-socket.h",
+        "srv-interface-tcp.h",
     ],
     copts = [
         "$(STACK_FRAME_UNLIMITED)",

--- a/libsrv/srv-interface-tcp.c
+++ b/libsrv/srv-interface-tcp.c
@@ -28,6 +28,7 @@ limitations under the License.
 #include "srvp.h"
 #include "srv-interface.h"
 #include "srv-interface-socket.h"
+#include "srv-interface-tcp.h"
 
 /*  Per-server session structure.  Just used to accept() and
  *  start new connections.
@@ -287,7 +288,8 @@ static bool tcp_socket_is_lost(cl_handle *cl, int fd) {
   cl_log(cl, CL_LEVEL_VERBOSE, "tcp_socket_is_lost(%d)", fd);
   if (level_tcp == -1) {
     struct protoent *pe;
-    level_tcp = ((pe = getprotobyname("TCP")) == NULL) ? SOL_TCP : pe->p_proto;
+    // IPPROTO_TCP should be more portable than TCP_SOL.
+    level_tcp = ((pe = getprotobyname("TCP")) == NULL) ? IPPROTO_TCP : pe->p_proto;
   }
 
   memset(&inf, 0, sizeof inf);

--- a/libsrv/srv-interface-tcp.h
+++ b/libsrv/srv-interface-tcp.h
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef SRV_INTERFACE_TCP_H
+#define SRV_INTERFACE_TCP_H 1
+
+#if __FreeBSD__
+
+/* TCP state names differ on FreeBSD, so we're defining the Linux variants with
+ * their FreeBSD counterparts.
+ */
+#include <netinet/tcp_fsm.h>
+
+#define TCP_ESTABLISHED TCPS_ESTABLISHED
+#define TCP_SYN_SENT TCPS_SYN_SENT
+#define TCP_SYN_RECV TCPS_SYN_RECEIVED
+#define TCP_FIN_WAIT1 TCPS_FIN_WAIT_1
+#define TCP_FIN_WAIT2 TCPS_FIN_WAIT_2
+#define TCP_TIME_WAIT TCPS_TIME_WAIT
+#define TCP_CLOSE TCPS_CLOSED
+#define TCP_CLOSE_WAIT TCPS_CLOSE_WAIT
+#define TCP_LAST_ACK TCPS_LAST_ACK
+#define TCP_LISTEN TCPS_LISTEN
+#define TCP_CLOSING TCPS_CLOSING
+
+#endif /* __FreeBSD__ */
+
+#endif /* SRV_INTERFACE_TCP_H */


### PR DESCRIPTION
ENODATA is not defined in FreeBSD's errno.h, though EIO seems
appropriate.  As with OSX, use sysctl instead of sysinfo.  TCP state #defs
also differ on FreeBSD.  Proposed option is to define the Linux
variants as their FreeBSD counterparts.  The other option would be to
simply disable TCP_INFO gathering for FreeBSD.

Signed-off-by: pierogmorski <pierogmorski@gmail.com>