### PR TITLE
Add a tests/ dir and a "fake" graphd that can listen on a port and yo…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,5 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/google/graphd/go/graphd
+# gazelle:build_file_name BUILD, BUILD.bazel
+gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,16 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz"],
+    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
+)
+http_archive(
+    name = "bazel_gazelle",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.14.0/bazel-gazelle-0.14.0.tar.gz"],
+    sha256 = "c0a5739d12c6d05b6c1ad56f2200cb0b57c5a70e03ebd2f7b87ce88cabf09c7b",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()

--- a/go/graphd/BUILD
+++ b/go/graphd/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "connect.go",
+        "graphd.go",
+        "log.go",
+        "url.go",
+    ],
+    importpath = "github.com/google/graphd/go/graphd/go/graphd",
+    visibility = ["//visibility:public"],
+)

--- a/go/graphd/test/BUILD
+++ b/go/graphd/test/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fake.go"],
+    importpath = "github.com/google/graphd/go/graphd/go/graphd/test",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fake_test.go"],
+    embed = [":go_default_library"],
+)

--- a/go/graphd/test/fake.go
+++ b/go/graphd/test/fake.go
@@ -1,0 +1,52 @@
+// package fakegraphd implements a server used for testing graphd clients.
+// This package will start a TCP server on a specified port, and are able to behave
+// deterministically (and for testing, pathologically) with respect to configuration.
+package fakegraphd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+)
+
+type FakeGraphd struct {
+	Addr      string
+	Reply     string
+	replyLock sync.RWMutex
+}
+
+func New(addr string) *FakeGraphd {
+	return &FakeGraphd{Addr: addr}
+}
+
+func (f *FakeGraphd) SetReply(reply string) {
+	f.replyLock.Lock()
+	defer f.replyLock.Unlock()
+	f.Reply = reply
+}
+
+func (f *FakeGraphd) Start() (func() error, error) {
+	ln, err := net.Listen("tcp", f.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("Error starting graphd: %v", err)
+	}
+	log.Printf("Listening: %v", ln.Addr())
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				log.Printf("UH OH: %v", err)
+			}
+			log.Printf("Handle: %v", conn)
+			go f.handle(conn)
+		}
+	}()
+	return ln.Close, nil
+}
+
+func (f *FakeGraphd) handle(c net.Conn) {
+	f.replyLock.RLock()
+	defer f.replyLock.RUnlock()
+	fmt.Fprintf(c, f.Reply)
+}

--- a/go/graphd/test/fake_test.go
+++ b/go/graphd/test/fake_test.go
@@ -1,0 +1,42 @@
+package fakegraphd
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+)
+
+const addr = ":8081"
+
+var fg *FakeGraphd
+
+func TestFakeReply(t *testing.T) {
+	want := "ok ()\n"
+	fg.SetReply(want)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Errorf("Error connecting to fakegraphd: %v", err)
+	}
+	fmt.Fprintf(conn, "status ()\n")
+	r := bufio.NewReader(conn)
+	got, err := r.ReadString('\n')
+	if err != nil {
+		t.Errorf("Unexpected error reading response: %v", err)
+	}
+	if got != want {
+		t.Errorf("Unexpected reply after SetReply, got = %v, want = %v", got, want)
+	}
+}
+
+func TestMain(m *testing.M) {
+	fg = New(addr)
+	cleanup, err := fg.Start()
+	defer cleanup()
+	if err != nil {
+		log.Fatalf("Unexpected error starting fake graphd: %v", err)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
…u can set the reply for. Pretty simple stuff.

Also, add BUILD support with gazelle and generate some BUILD files.

Gazelle can be used anywhere in the repo, just run:

    bazel run //:gazelle

and poof, like magic, BUILD files appear.